### PR TITLE
rename scripts

### DIFF
--- a/benchmarks/config_examples/cpp_test.yml
+++ b/benchmarks/config_examples/cpp_test.yml
@@ -23,7 +23,7 @@
   period: 1
 
 
-- server_instance: CppBenchmarkTarget/test
+- server_instance: CppBenchmarkTarget/rtest
   device_class: CppBenchmarkTarget
   target_device: test/cppbenchmarktarget/01
   # host: localhost:10000

--- a/benchmarks/config_examples/default.json
+++ b/benchmarks/config_examples/default.json
@@ -21,6 +21,6 @@
      "title": "python pipe benchmark"},
 
     {"target_device": "test/pybenchmarktarget/01",
-     "server_instance": "PyBenchmarkTarget/test",
+     "server_instance": "PyBenchmarkTarget/rtest",
      "device_class": "PyBenchmarkTarget"}
 ]

--- a/benchmarks/config_examples/java_test.yml
+++ b/benchmarks/config_examples/java_test.yml
@@ -23,7 +23,7 @@
   period: 1
 
 
-- server_instance: JavaBenchmarkTarget/test
+- server_instance: JavaBenchmarkTarget/rtest
   device_class: JavaBenchmarkTarget
   target_device: test/javabenchmarktarget/01
   # host: localhost:10000

--- a/benchmarks/config_examples/test.yml
+++ b/benchmarks/config_examples/test.yml
@@ -21,5 +21,5 @@
 
 - target_device: p00/pybenchmarktarget/01
   device_class: PyBenchmarkTarget
-  server_instance: PyBenchmarkTarget/test1
+  server_instance: PyBenchmarkTarget/rtest1
   # host: localhost:10000

--- a/benchmarks/config_examples/test2.yml
+++ b/benchmarks/config_examples/test2.yml
@@ -1,13 +1,13 @@
 - target_device: test/pybenchmarktarget/01
   device_class: PyBenchmarkTarget
-  server_instance: PyBenchmarkTarget/test
+  server_instance: PyBenchmarkTarget/rtest
   # host: localhost
 - target_device: test/cppbenchmarktarget/01
   device_class: CppBenchmarkTarget
-  server_instance: CppBenchmarkTarget/test
+  server_instance: CppBenchmarkTarget/rtest
   # host: localhost
 - target_device: test/javabenchmarktarget/01
   device_class: JavaBenchmarkTarget
-  server_instance: JavaBenchmarkTarget/test
+  server_instance: JavaBenchmarkTarget/rtest
   # host: localhost
 

--- a/benchmarks/default.yml
+++ b/benchmarks/default.yml
@@ -23,7 +23,7 @@
   period: 1
 
 
-- server_instance: PyBenchmarkTarget/test
+- server_instance: PyBenchmarkTarget/rtest
   device_class: PyBenchmarkTarget
   target_device: test/pybenchmarktarget/01
   # host: localhost:10000

--- a/benchmarks/setup.py
+++ b/benchmarks/setup.py
@@ -88,12 +88,12 @@ SETUPDATA = dict(
     install_requires=install_requires,
     entry_points={
         'console_scripts': [
-            'pipebenchmark = benchmarks.pipebenchmark:main',
-            'readbenchmark = benchmarks.readbenchmark:main',
-            'writebenchmark = benchmarks.writebenchmark:main',
-            'eventbenchmark = benchmarks.eventbenchmark:main',
-            'cmdbenchmark = benchmarks.cmdbenchmark:main',
-            'benchmarkrunner = benchmarks.runner:main',
+            'tg_pipebenchmark = benchmarks.pipebenchmark:main',
+            'tg_readbenchmark = benchmarks.readbenchmark:main',
+            'tg_writebenchmark = benchmarks.writebenchmark:main',
+            'tg_eventbenchmark = benchmarks.eventbenchmark:main',
+            'tg_cmdbenchmark = benchmarks.cmdbenchmark:main',
+            'tg_benchmarkrunner = benchmarks.runner:main',
         ]},
     author='Jan Kotanski, Piotr Goryl',
     author_email='jankotan at gmail.com, piotr.goryl at s2innovation.com',

--- a/benchmarks/test/BenchmarkRunner_test.py
+++ b/benchmarks/test/BenchmarkRunner_test.py
@@ -110,7 +110,7 @@ class BenchmarkRunnerTest(unittest.TestCase):
         print("Run: %s.%s() " % (
             self.__class__.__name__, sys._getframe().f_code.co_name))
 
-        vl, er = self.runscript(['benchmarkrunner'])
+        vl, er = self.runscript(['tg_benchmarkrunner'])
 
         self.assertEqual('', er)
         self.assertTrue(vl)

--- a/ds/PyBenchmarkTarget/test/PyBenchmarkTarget_test.py
+++ b/ds/PyBenchmarkTarget/test/PyBenchmarkTarget_test.py
@@ -578,8 +578,8 @@ class PyBenchmarkTargetDeviceTest(unittest.TestCase):
         tbr2 = time.time()
         tsr = self.proxy.TimeSinceReset
         tar2 = time.time()
-        self.assertTrue(tbr2 - tar1 < tsr)
-        self.assertTrue(tar2 - tbr1 > tsr)
+        self.assertTrue(tbr2 - tar1 <= tsr)
+        self.assertTrue(tar2 - tbr1 >= tsr)
 
     def test_BenchmarkSpectrumAttribute(self):
         """Test for BenchmarkSpectrumAttribute"""


### PR DESCRIPTION
I renames benchmark scripts:

    *benchmark* -> tg_*benchmark*

to avoid name clutches with other system benchmarks 