### PR TITLE
Adding -E option to sudo call in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ For client side (benchmark runners):
     - the C++ target
         - `cd ../CppBenchmarkTarget`
         - `make`
-        - `sudo make install`
+        - `sudo -E make install`
     - the Java target
         - `cd ../JavaBenchmarkTarget`
         - `mvn clean install`


### PR DESCRIPTION
At Ubuntu 18.04 sudo seems to clean environment if not called with -E