### PR TITLE
Fix setup.py install requirements handling

### DIFF
--- a/ds/PyBenchmarkTarget/setup.py
+++ b/ds/PyBenchmarkTarget/setup.py
@@ -26,10 +26,18 @@ import sys
 import subprocess
 from setuptools import setup
 from distutils.core import Command
-from sphinx.setup_command import BuildDoc
-from PyBenchmarkTarget.release import name, version
+cmd_class = {}
+try:
+    from sphinx.setup_command import BuildDoc
+    cmd_class['build_sphinx'] = BuildDoc
+except ImportError:
+    print("WARNING: sphinx not available, not adding 'build_sphinx' command.")
 
 setup_dir = os.path.dirname(os.path.abspath(__file__))
+
+release_info = {}
+exec(open(os.path.join('PyBenchmarkTarget', 'release.py')).read(),
+     release_info)
 
 # make sure we use latest info from local code
 sys.path.insert(0, setup_dir)
@@ -65,10 +73,13 @@ class TestCommand(Command):
         raise SystemExit(errno)
 
 
+cmd_class['test'] = TestCommand
+
+
 #: metadata for distutils
 SETUPDATA = dict(
-    name=name,
-    version=version,
+    name=release_info['name'],
+    version=release_info['version'],
     description='Benchmark device for counting attribute, '
     'command and pipe calls',
     packages=pack,
@@ -82,7 +93,8 @@ SETUPDATA = dict(
     long_description=long_description,
     url='www.tango-controls.org',
     platforms="All Platforms",
-    cmdclass={'test': TestCommand, 'build_sphinx': BuildDoc},
+    install_requires=['sphinx', 'numpy'],
+    cmdclass=cmd_class
 )
 
 


### PR DESCRIPTION
Minor updates to `setup.py` to fix an issue where in order to install the package using `python setup.py install` or `pip install .`, it is first necessary to install sphinx and other package dependencies (ie. numpy). This is a problem as it will prevent new users being able to install the package without generating an error.

In order to address these issues, this change:

1. Makes sphinx (and therefore the custom `build_sphinx` command) an optional command by catching the ImportError exception raised when trying to import sphinx.
2. Obtains the package name and version without importing the `PyBenchmarkTarget` package. Importing the package in the `setup.py` introduces a race condition whereby package dependencies are needed for this import statement to be resolved. This can be avoided by executing (https://docs.python.org/3/library/functions.html#exec) `release.py` and returning the release parameters as a dictionary of globals from that file. This approach follows technique 3. listed at https://packaging.python.org/guides/single-sourcing-package-version/
3. Added `install_requires` to package data to specify the package requirements.