### PR TITLE
fix misprint for EventThread loop of cpp device server

### DIFF
--- a/ds/CppBenchmarkTarget/EventThread.cpp
+++ b/ds/CppBenchmarkTarget/EventThread.cpp
@@ -24,7 +24,7 @@ namespace CppBenchmarkTarget_ns
   void* EventThread::run_undetached(void*)
   {
     bool loop = true;
-    while(running){
+    while(loop){
       try{
 	{
 	  Tango::AutoTangoMonitor synch(m_objServer);


### PR DESCRIPTION
It fixes misprint for EventThread loop of cpp device server. The previous code is not fully thread-safe